### PR TITLE
add on_blast() support to fix https://github.com/lord-server/lord/issues/2383

### DIFF
--- a/painting.lua
+++ b/painting.lua
@@ -427,7 +427,19 @@ core.register_node("painting:canvasnode", {
 		item_meta:set_string("version", data.version)
 		item_meta:set_string("grid", painting.compress(core.serialize(data.grid)))
 		digger:get_inventory():add_item("main", item)
-	end
+	end,
+	
+	on_blast = function(pos, intensity)
+		for obj in core.objects_inside_radius(pos, 0.1) do
+			local e = obj:get_luaentity()
+			if e.name == "painting:paintent" then
+				e.object:set_hp(0)
+				-- suppose there can be only one paintent on a canvas
+				break
+			end
+		end
+		core.remove_node(pos)
+	end,
 })
 
 local easelbox = { -- Specifies 3d model.
@@ -524,7 +536,20 @@ core.register_node("painting:easel", {
 
 	can_dig = function(pos)
 		return core.get_meta(pos):get_int("has_canvas") == 0
-	end
+	end,
+	
+	on_blast = function(pos, intensity)
+		if core.get_meta(pos):get_int("has_canvas") == 1 then
+			local canvas_pos = {x = pos.x, y = pos.y + 1, z = pos.z}
+			local canvas_node = core.get_node(canvas_pos)
+			local canvas_node_def = core.registered_nodes[canvas_node.name]
+			
+			if canvas_node_def.on_blast then
+				canvas_node_def.on_blast(canvas_pos)
+			end
+		end
+		core.remove_node(pos)
+	end,
 })
 
 --brushes


### PR DESCRIPTION
The problem described in https://github.com/lord-server/lord/issues/2383 is that if a node has no defined behaviour for explosions then some mods will just use `core.punch_node` or `core.remove_node` on `painting:canvasnode` or `painting:easel` thus leaving behind a lonely immortal `painting:paintent` entity to be drawn upon. This is not good.

The proposed solution is to add `on_blast` callbacks that ensure that if `painting:canvasnode` or `painting:easel` are to be destroyed by an explosion then `painting:paintent` will go down as well despite its immortal status.