### PR TITLE
Fix server crash caused by an attempt to place a canvas on an easel with param2 value bigger than 3

### DIFF
--- a/painting.lua
+++ b/painting.lua
@@ -482,6 +482,12 @@ core.register_node("painting:easel", {
 			return
 		end
 		local fd = node.param2
+
+		-- prevent server crash in case that easel was rotated in 3D
+		if fd > 3 then
+			return
+		end
+
 		core.add_node(pos, { name = "painting:canvasnode", param2 = fd})
 
 		local dir = dirs[fd]


### PR DESCRIPTION
This is a solution to the bug described here: https://github.com/lord-server/lord/issues/2380

In short, there are mods (like [screwdriver](https://github.com/minetest-game-mod/screwdriver)) that rotate nodes in 3D which results in `param2` node property to store values 0..23.
However, current mod logic supports only rotation in 2D, so `dirs` table can be indexed from 0 to 3 only. 
Thus, attempting to access dirs[4], for example, will make server crash spectacularly, which happens if canvas is being placed on an easel that was rotated upside-down.

The proposed rough solution is to prevent canvas from being placed on an easel with param2 value that is bigger than 3.