### PR TITLE
Add support for lottfarming mod.

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = painting
 description = In-game painting mod for minetest
-optional_depends = vector_extras, default, farming, mcl_core, hades_bucket, hades_extrafarming, sculpture, petz, mobs_animal, hades_animals, hades_petz, animalia, hades_animalia, tga_encoder
+optional_depends = vector_extras, default, farming, lottfarming, mcl_core, hades_bucket, hades_extrafarming, sculpture, petz, mobs_animal, hades_animals, hades_petz, animalia, hades_animalia, tga_encoder

--- a/oil_color.lua
+++ b/oil_color.lua
@@ -9,6 +9,9 @@ local empty_bottle = "vessels:glass_bottle"
 local feather = nil
 local feather_img = nil
 
+if core.get_modpath("lottfarming") then
+	oil_bottle = "lottfarming:vegetable_oil"
+end
 if core.get_modpath("petz") then
 	feather = "petz:dcuky_feather"
 	feather_img = "petz_ducky_feather.png"


### PR DESCRIPTION
Add support for `lottfarming` mod by "telling" `painting` mod how oil_bottle is called in `lottfarming` and by adding `lottfarming` in optional dependencies.